### PR TITLE
Switch to apollo-server-express 

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@babel/plugin-transform-runtime": "^7.13.15",
     "@babel/preset-env": "^7.7.1",
     "@babel/runtime": "^7.13.10",
-    "apollo-server-testing": "^2.22.2",
+    "apollo-server-integration-testing": "^3.0.0",
     "dotenv": "^6.2.0",
     "dotenv-override": "^5.0.1",
     "graphql-type-json": "^0.3.1",
@@ -65,7 +65,8 @@
     ]
   },
   "dependencies": {
-    "apollo-server": "^2.22.2",
+    "apollo-server-express": "^3.5.0",
+    "graphql": "^16.0.1",
     "graphql-tag": "^2.10.3",
     "graphql-tools": "^7.0.4",
     "jsonwebtoken": "^8.5.1"

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,4 +1,4 @@
-import { ApolloError } from "apollo-server";
+import { ApolloError } from "apollo-server-express";
 
 class AuthorizationError extends ApolloError {
   constructor({ message = "You are not authorized." }) {

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -1,4 +1,4 @@
-import { UserInputError } from "apollo-server";
+import { UserInputError } from "apollo-server-express";
 
 // dictionary with indicator of condition and function to retrieve conditional query based on userId and crudObjectId
 export let conditionalQueryMap = new Map(); // initialize as empty map -> editable by end user

--- a/test/__tests__/test.js
+++ b/test/__tests__/test.js
@@ -1,9 +1,6 @@
-import { createTestClient } from "apollo-server-testing";
+import { createTestClient } from "apollo-server-integration-testing";
 import { scopes } from "../helpers/test-data";
 import { server } from "../helpers/test-setup";
-
-import gql from "graphql-tag";
-
 beforeAll(() => {});
 
 afterAll(async done => {
@@ -21,22 +18,23 @@ beforeEach(() => {
 
 describe("Permissions without a provided token", () => {
   test("Fail if no visitor access is provided", async () => {
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
-    const result = await query({
-      query: gql`
+    const result = await query(`
         {
           userById(userId: "123456") {
             id
             name
           }
         }
-      `
-    });
+      `);
 
     expect(result.data.userById).toBeNull();
     expect(result.errors[0].message).toEqual("No authorization token.");
   });
+
   test("Fail if wrong token is provided", async () => {
     const token = "awefawe";
 
@@ -44,38 +42,39 @@ describe("Permissions without a provided token", () => {
       req: { headers: { authorization: `Bearer ${token}` } }
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
-    const result = await query({
-      query: gql`
+    const result = await query(`
         {
           userById(userId: "123456") {
             id
             name
           }
         }
-      `
-    });
+      `);
 
     expect(result.data.userById).toBeNull();
     expect(result.errors[0].message).toEqual(
       "You are not authorized for this resource."
     );
   });
+
   test("Success if visitor permissions is provided", async () => {
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
     try {
-      const result = await query({
-        query: gql`
+      const result = await query(`
           {
             itemById(itemId: 1) {
               id
               name
             }
           }
-        `
-      });
+        `);
 
       const expectedResult = {
         id: "123",
@@ -95,25 +94,24 @@ describe("Permissions without a provided token", () => {
 describe("Permission with a provided token", () => {
   test("Success if the required permissions are provided in the form of role based permissions", async () => {
     const token =
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTg4ODQ2NjU1LCJleHAiOjE2MjAzODI2NTUsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsInJvbGUiOiJhZG1pbiJ9.Io4L4ougLgBQ9MWotu5I3MOFCoed6NIhsaaBJ2UXotc";
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTQ5MTQ1Mjk0LCJleHAiOjE2OTE3ODEzMDcsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsInJvbGUiOiJhZG1pbiJ9.KRuzHFjQTt__bjcYh9x6hgQY4iu4S-zNa4fDL_NVsPk";
 
     server.mergeContext({
       req: { headers: { authorization: `Bearer ${token}` } }
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
     try {
-      const result = await mutate({
-        mutation: gql`
+      const result = await mutate(`
           mutation {
             createItem(id: 1, name: "test") {
               id
             }
           }
-        `
-      });
-
+        `);
       expect(result.data.createItem.id).toEqual(1);
     } catch (e) {}
 
@@ -127,18 +125,18 @@ describe("Permission with a provided token", () => {
       req: { headers: { authorization: `Bearer ${token}` } }
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
     try {
-      const result = await mutate({
-        mutation: gql`
+      const result = await mutate(`
           mutation {
             createUser(id: 1, name: "test") {
               id
             }
           }
-        `
-      });
+        `);
 
       expect(result.data.createUser).toBeNull();
       expect(result.errors[0].message).toEqual(
@@ -152,25 +150,24 @@ describe("Permission with a provided token", () => {
   });
   test("Success if the required permissions are provided in the form of scopes", async () => {
     const token =
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTg4ODQ2NjU1LCJleHAiOjE2MjAzODI2NTUsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsInNjb3BlIjoidXNlcjpkZWxldGUifQ.YJ1AFRWLyVINzDKvLZhHHGtrjvLQDGGKa6OcHowedik";
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTQ5MTQ1Mjk0LCJleHAiOjE2OTE3ODEzMDcsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsInNjb3BlIjoidXNlcjpkZWxldGUifQ.gTXbNaLh62alQhwELBxmaw8zCi-FwvEC5_NExqNumTM";
 
     server.mergeContext({
       req: { headers: { authorization: `Bearer ${token}` } }
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
     try {
-      const result = await mutate({
-        mutation: gql`
+      const result = await mutate(`
           mutation {
             deleteUser(id: 1) {
               id
             }
           }
-        `
-      });
-
+        `);
       expect(result.data.deleteUser.id).toEqual(1);
     } catch (e) {}
 
@@ -178,24 +175,24 @@ describe("Permission with a provided token", () => {
   });
   test("Fail if insufficient permissions are provided in the form of scopes", async () => {
     const token =
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTg4ODQ2NjU1LCJleHAiOjE2MjAzODI2NTUsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsInNjb3BlIjoidXNlcjpkZWxldGUifQ.YJ1AFRWLyVINzDKvLZhHHGtrjvLQDGGKa6OcHowedik";
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTQ5MTQ1Mjk0LCJleHAiOjE2OTE3ODEzMDcsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsInNjb3BlIjoidXNlcjpkZWxldGUifQ.gTXbNaLh62alQhwELBxmaw8zCi-FwvEC5_NExqNumTM";
 
     server.mergeContext({
       req: { headers: { authorization: `Bearer ${token}` } }
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
     try {
-      const result = await mutate({
-        mutation: gql`
+      const result = await mutate(`
           mutation {
             createUser(id: 1, name: "test") {
               id
             }
           }
-        `
-      });
+        `);
 
       expect(result.data.createUser).toBeNull();
       expect(result.errors[0].message).toEqual(
@@ -211,66 +208,66 @@ describe("Permission with a provided token", () => {
 
 describe("@hasScope: Roles and permissions are attached to the user", () => {
   test("Visitor roles are attached if no token is provided", async () => {
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
-    const result = await query({
-      query: gql`
+    const result = await query(`
         query {
           me {
             roles
             scopes
           }
         }
-      `
-    });
+      `);
 
     expect(result.data.me.roles).toEqual("visitor");
     expect(result.data.me.scopes).toEqual(scopes.visitor);
   });
   test("Admin roles and scopes are attached if a token is provided", async () => {
     const token =
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTg4ODQ2NjU1LCJleHAiOjE2MjAzODI2NTUsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsInJvbGUiOiJhZG1pbiJ9.Io4L4ougLgBQ9MWotu5I3MOFCoed6NIhsaaBJ2UXotc";
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTQ5MTQ1Mjk0LCJleHAiOjE2OTE3ODEzMDcsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsInJvbGUiOiJhZG1pbiJ9.KRuzHFjQTt__bjcYh9x6hgQY4iu4S-zNa4fDL_NVsPk";
 
     server.mergeContext({
       req: { headers: { authorization: `Bearer ${token}` } }
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
-    const result = await query({
-      query: gql`
+    const result = await query(`
         query {
           me {
             roles
             scopes
           }
         }
-      `
-    });
+      `);
 
     expect(result.data.me.roles).toEqual("admin");
     expect(result.data.me.scopes).toEqual(scopes.admin);
   });
   test("Admin roles and scopes are attached if a token is provided with multiple roles - using meta mapper: https://www.example.com/role", async () => {
     const token =
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MDUyODIwNjgsImV4cCI6MTc2MzA0ODQ2OCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6Ik5hdGhhbiIsIlN1cm5hbWUiOiJNZWliZXJnZW4iLCJFbWFpbCI6Im5tQGVpLmNvbSIsImh0dHA6Ly93d3cuZXhhbXBsZS5jb20vcm9sZSI6WyJhZG1pbiIsImVkaXRvciJdfQ.TOP75bHu-lI4ZXRBl7L5cud_W68L1u9r9DtBH3qRnFs";
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTQ5MTQ1Mjk0LCJleHAiOjE2OTE3ODEzMDcsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsIkdpdmVuTmFtZSI6Ik5hdGhhbiIsIlN1cm5hbWUiOiJNZWliZXJnZW4iLCJFbWFpbCI6Im5tQGVpLmNvbSIsImh0dHA6Ly93d3cuZXhhbXBsZS5jb20vcm9sZSI6WyJhZG1pbiIsImVkaXRvciJdfQ.CXptQNiiQFsQ6y9kGWPnY_VB586rUA53o4NWX7JltAY";
 
     server.mergeContext({
       req: { headers: { authorization: `Bearer ${token}` } }
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
-    const result = await query({
-      query: gql`
+    const result = await query(`
         query {
           me {
             roles
             scopes
           }
         }
-      `
-    });
+      `);
 
     expect(result.data.me.roles).toEqual(["admin", "editor"]);
     expect(result.data.me.scopes).toEqual(scopes.admin.concat(scopes.editor));
@@ -309,18 +306,18 @@ describe("@hasScope: Roles and permissions are attached to the user", () => {
       driver: driver
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
-    const result = await mutate({
-      mutation: gql`
+    const result = await mutate(`
         mutation {
           updateItemConditionfalse(id: 1, name: "newname") {
             id
             name
           }
         }
-      `
-    });
+      `);
 
     expect(result.errors[0].message).toEqual(
       "You are not authorized for this resource."
@@ -357,18 +354,18 @@ describe("@hasScope: Roles and permissions are attached to the user", () => {
       driver: driver
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
-    const result = await mutate({
-      mutation: gql`
+    const result = await mutate(`
         mutation {
           updateItemConditiontrue(id: 1, name: "newname") {
             id
             name
           }
         }
-      `
-    });
+      `);
 
     expect(result.data.updateItemConditiontrue.id).toEqual("123");
   });
@@ -403,18 +400,18 @@ describe("@hasScope: Roles and permissions are attached to the user", () => {
       driver: driver
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
-    const result = await mutate({
-      mutation: gql`
+    const result = await mutate(`
         mutation {
           updateItem(id: 1, name: "newname") {
             id
             name
           }
         }
-      `
-    });
+      `);
 
     expect(result.data.updateItem.id).toEqual("123");
   });
@@ -449,18 +446,18 @@ describe("@hasScope: Roles and permissions are attached to the user", () => {
       driver: driver
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
-    const result = await mutate({
-      mutation: gql`
+    const result = await mutate(`
         mutation {
           updateItemMultiCondition(id: 1, name: "newname") {
             id
             name
           }
         }
-      `
-    });
+      `);
 
     expect(result.data.updateItemMultiCondition.id).toEqual("123");
   });
@@ -470,18 +467,18 @@ describe("@hasScope: Roles and permissions are attached to the user", () => {
       driver: null
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
-    const result = await mutate({
-      mutation: gql`
+    const result = await mutate(`
         mutation {
           updateItemConditiontrue(id: 1, name: "newname") {
             id
             name
           }
         }
-      `
-    });
+      `);
 
     expect(result.errors[0].message).toEqual(
       "No driver to the database is provided, therefore conditional scopes cannot be verified."
@@ -492,24 +489,24 @@ describe("@hasScope: Roles and permissions are attached to the user", () => {
 describe("@isAuthenticated: Roles and permissions are attached to the user", () => {
   test("Admin roles and scopes are attached if a token is provided", async () => {
     const token =
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTg4ODQ2NjU1LCJleHAiOjE2MjAzODI2NTUsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsInJvbGUiOiJhZG1pbiJ9.Io4L4ougLgBQ9MWotu5I3MOFCoed6NIhsaaBJ2UXotc";
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTQ5MTQ1Mjk0LCJleHAiOjE2OTE3ODEzMDcsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsInJvbGUiOiJhZG1pbiJ9.KRuzHFjQTt__bjcYh9x6hgQY4iu4S-zNa4fDL_NVsPk";
 
     server.mergeContext({
       req: { headers: { authorization: `Bearer ${token}` } }
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
-    const result = await query({
-      query: gql`
+    const result = await query(`
         query {
           authMe {
             roles
             scopes
           }
         }
-      `
-    });
+      `);
 
     expect(result.data.authMe.roles).toEqual("admin");
     expect(result.data.authMe.scopes).toEqual(scopes.admin);
@@ -518,39 +515,39 @@ describe("@isAuthenticated: Roles and permissions are attached to the user", () 
 
 describe("@hasRole: Roles and permissions are attached to the user", () => {
   test("Visitor roles are attached if no token is provided", async () => {
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
-    const result = await query({
-      query: gql`
+    const result = await query(`
         query {
           roleMe {
             roles
           }
         }
-      `
-    });
+      `);
 
     expect(result.data.roleMe.roles).toEqual("visitor");
   });
   test("Admin roles are attached if a token is provided", async () => {
     const token =
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTg4ODQ2NjU1LCJleHAiOjE2MjAzODI2NTUsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsInJvbGUiOiJhZG1pbiJ9.Io4L4ougLgBQ9MWotu5I3MOFCoed6NIhsaaBJ2UXotc";
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHUkFORHN0YWNrIiwiaWF0IjoxNTQ5MTQ1Mjk0LCJleHAiOjE2OTE3ODEzMDcsImF1ZCI6ImdyYW5kc3RhY2suaW8iLCJzdWIiOiJib2JAbG9ibGF3LmNvbSIsInJvbGUiOiJhZG1pbiJ9.KRuzHFjQTt__bjcYh9x6hgQY4iu4S-zNa4fDL_NVsPk";
 
     server.mergeContext({
       req: { headers: { authorization: `Bearer ${token}` } }
     });
 
-    const { query, mutate } = createTestClient(server);
+    const { query, mutate } = createTestClient({
+      apolloServer: server
+    });
 
-    const result = await query({
-      query: gql`
+    const result = await query(`
         query {
           roleMe {
             roles
           }
         }
-      `
-    });
+      `);
 
     expect(result.data.roleMe.roles).toEqual("admin");
   });

--- a/test/helpers/test-setup.js
+++ b/test/helpers/test-setup.js
@@ -1,8 +1,7 @@
 // TODO: will need to set appropriate env vars
 
-import { ApolloServer } from "apollo-server";
+import { ApolloServer } from "apollo-server-express";
 import { makeExecutableSchema } from "graphql-tools";
-import GraphQLJSON from "graphql-type-json";
 import * as permissions from "../../src/permissions";
 
 const {
@@ -202,5 +201,7 @@ const server = new ApolloTestServer({
   //   console.log(`GraphQL server ready at ${url}`);
   // >>>>>>> c09bb0fe60447ae7bcb53670a49c8e12dc3cd46b
 });
+
+server.start();
 
 module.exports.server = server;


### PR DESCRIPTION
Currently this project is able to support apollo-server 2.22.2 which is outdated. What I did here is upgrade the version to 3.5.0 and move to apollo-server-express to be able to run the test using apollo-server-integration-testing since apollo-server-testing is deprecated. Also I found this in the documentation of asit: 

`You can't really write real integration tests with apollo-server-testing, because it doesn't support servers which rely on the context option being a function that uses the req object link: [apollo server integration testing](https://www.npmjs.com/package/apollo-server-integration-testing)`

All tests are passing.
Updated all JWT to increase the expiration time.